### PR TITLE
Fix empty_world.launch requesting bad node for ROS Indigo

### DIFF
--- a/cvg_sim_gazebo/launch/empty_world.launch
+++ b/cvg_sim_gazebo/launch/empty_world.launch
@@ -1,8 +1,12 @@
+<?xml version="1.0"?>
 <launch>
-  <param name="/use_sim_time" value="true" />
-  <node name="empty_world_server" pkg="gazebo" type="gazebo" args="$(find cvg_sim_gazebo)/worlds/empty.world" respawn="false" output="screen">
+  <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+  </include>
 
-  </node>
-  <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+
+  <!-- Spawn simulated quadrotor uav -->
+  <include file="$(find cvg_sim_gazebo)/launch/spawn_quadrotor.launch" >
+    <arg name="model" value="$(find cvg_sim_gazebo)/urdf/quadrotor_sensors.urdf.xacro"/> 
+  </include>
 </launch>
-


### PR DESCRIPTION
Allows empty_world.launch to function properly when launched, instead of giving an error about being unable to find the gazebo node.
